### PR TITLE
SCRUM 51 superpool setup codecov for coverage metrics tracking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,53 @@
+# coverage.yml
+#
+# Created: 2024-06-11 18:35
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        paths:
+          - "superpool/api/"
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "tests/"
+  - "superpool/api/tests/"
+  - "**/__pycache__/"
+  - "**/*.pyc"
+  - "superpool/api/config/"
+  - "superpool/api/settings/"
+  - "superpool/api/migrations/"
+
+# Helps logs a formatted output to the stdout
+comment:
+  layout: "reach, diff, files, footer"
+  behavior: default
+  require_changes: true
+
+codecov:
+  notify:
+    after_n_builds: 1
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+yaml:
+  # paths to include or exclude for the coverage report
+  whitelist:
+    - "superpool/api/"
+  blacklist:
+    - "**/__pycache__/"
+    - "**/*.pyc"
+    - "superpool/api/config/"
+    - "superpool/api/settings/"
+    - "superpool/api/migrations/"
+    - "superpool/api/tests/"
+    - "tests/"
+

--- a/superpool/.coveragerc
+++ b/superpool/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+# disable tracking of branch coverage
+branch=False
+relative_files=True
+
+[report]
+# We don't want to run coverage for migrations and tests,
+# We only care about application logic only
+omit = */templates/*, */tests/*, **/migrations/*, **/__init__.py, */generated/*
+include=
+    api/**/*
+
+# Don't show files with 100% coverage and show missing lines
+skip_covered = True
+show_missing = True
+
+[html]
+directory = coverage_report
+

--- a/superpool/api/Makefile
+++ b/superpool/api/Makefile
@@ -13,5 +13,5 @@ make_migrations:
 	python manage.py makemigrations
 
 clear_py_cache:
-	find . -name "**/*.pyc" -delete
-	find . -name "**/__pycache__" -delete
+	find . -path "**/*.pyc" -delete
+	find . -path "**/__pycache__" -delete


### PR DESCRIPTION
- **fix: path seperator in clear `pycache` command**
- **Implement `coverage` tracking with CodeCov**
- **fix(coverage): setup `codecov.yml` config in root path**
