### PR TITLE
resolve `testpath` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Run tests with Codecov
 on:
   pull_request:
     branches:
-       - dev
+      - dev
 
 permissions:
   packages: write
@@ -19,22 +19,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
+
       - name: Setup Python
         uses: actions/setup-python@v2
-            
+
       - name: Install dependencies
         run: pip install -r requirements.txt
-      
+
       - name: Run test
-        run: pytest superpool/api/tests/
-      
+        run: pytest superpool/api/
+
       - name: Generate coverage report
         run: |
-              pip install pytest
-              pip install pytest-cov
-              pytest --cov=./ --cov-report=xml
-      
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
This patch corrects the file path for pytest to pick up the test files.
The path was incorrect and was causing the tests to fail.

This PR corrects the path and the tests should now pass.
