### PR TITLE
Integrations(Heirs API) - integrate all policies registration endpoints

### DIFF
--- a/superpool/api/api/catalog/serializers.py
+++ b/superpool/api/api/catalog/serializers.py
@@ -78,10 +78,18 @@ class QuoteSerializer(serializers.ModelSerializer):
         fields = ("id", "base_price")
 
 
-class PolicyPurchaseSerializer(serializers.ModelSerializer):
+class PolicyPurchaseSerializer(serializers.Serializer):
     """
-    Issues a new policy based on CustomerDetails,
+    Issues a new policy based on CustomerDetails and some
+    other metadata
     """
 
-    class Meta:
-        model = Policy
+    customer_details = serializers.JSONField()
+    category = serializers.CharField()
+    product_id = serializers.UUIDField()
+    coverage_id = serializers.UUIDField()
+    merchant_id = serializers.UUIDField()
+    provider_id = serializers.UUIDField()
+    renewable = serializers.BooleanField(required=False)
+    inspection_required = serializers.BooleanField(required=False)
+    certification_required = serializers.BooleanField(required=False)

--- a/superpool/api/api/catalog/serializers.py
+++ b/superpool/api/api/catalog/serializers.py
@@ -70,3 +70,18 @@ class CreatePolicySerializer(ModelSerializer):
             "renewable",
         )
         exclude = ("cerfication_required", "inspection_required")
+
+
+class QuoteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Policy
+        fields = ("id", "base_price")
+
+
+class PolicyPurchaseSerializer(serializers.ModelSerializer):
+    """
+    Issues a new policy based on CustomerDetails,
+    """
+
+    class Meta:
+        model = Policy

--- a/superpool/api/api/catalog/urls.py
+++ b/superpool/api/api/catalog/urls.py
@@ -1,8 +1,14 @@
 import typing
 
 from django.urls import include, path
+from rest_framework.routers import DefaultRouter
 
-from .views import PolicyListView, ProductListView, ProductView
+from .views import (PolicyAPIViewSet, PolicyListView, ProductListView,
+                    ProductView)
+
+router = DefaultRouter()
+
+router.register(r"policies")
 
 if typing.TYPE_CHECKING:
     from django.urls import URLPattern, URLResolver
@@ -15,4 +21,24 @@ urlpatterns: typing.List[typing.Union["URLPattern", "URLResolver"]] = [
         name="product-detail",
     ),
     path("policies", PolicyListView.as_view(), name="policy-list"),
+    # path(
+    #     "policies/<uuid:pk>/",
+    #     PolicyAPIViewSet.as_view({"get": "retrieve"}),
+    #     name="policy-detail",
+    # ),
+    # path(
+    #     "policies/search/",
+    #     PolicyAPIViewSet.as_view({"get": "list"}),
+    #     name="policy-search",
+    # ),
+    # path(
+    #     "policies/purchase/",
+    #     PolicyAPIViewSet.as_view({"post": "purchase"}),
+    #     name="policy-purchase",
+    # ),
+    # path(
+    #     "policies/renew/",
+    #     PolicyAPIViewSet.as_view({"post": "renew"}),
+    #     name="policy-renew",
+    # ),
 ]

--- a/superpool/api/api/catalog/urls.py
+++ b/superpool/api/api/catalog/urls.py
@@ -8,7 +8,7 @@ from .views import (PolicyAPIViewSet, PolicyListView, ProductListView,
 
 router = DefaultRouter()
 
-router.register(r"policies")
+router.register(r"policies", PolicyAPIViewSet)
 
 if typing.TYPE_CHECKING:
     from django.urls import URLPattern, URLResolver

--- a/superpool/api/api/catalog/views.py
+++ b/superpool/api/api/catalog/views.py
@@ -167,38 +167,19 @@ class PolicyAPIViewSet(
         This action allows you to generate a new policy for your
         customer
         """
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        validated_data = serializer.validated_data
+        # generate a new policy for the customer
+        # Construct a new policy object, and return both the policy number and the policy ID
 
-        customer_details = validated_data["customer_details"]
+        # emit a policy purchased signal that fires up a background task to notify the admins
+        # of the platform
 
-        try:
-            with transaction.atomic():
-                # generate a new policy for the customer
-                # Construct a new policy object, and return both the policy number and the policy ID
+        # fires off a background process that post (actually register the customer info) and
+        # the policy information to the insurer endpoint
+        # (we should just call a function in a service that would integrate the Insurer APIs)
 
-                # emit a policy purchased signal that fires up a background task to notify the admins
-                # of the platform
+        # returrn the policy ID, Policy Number, and the status of the policy to the merchant
 
-                # fires off a background process that post (actually register the customer info) and
-                # the policy information to the insurer endpoint
-                # (we should just call a function in a service that would integrate the Insurer APIs)
-
-                # returrn the policy ID, Policy Number, and the status of the policy to the merchant
-                return Response(
-                    {
-                        "message": "Policy successfully purchased.",
-                        "data": policy_serializer.data,
-                    },
-                    status=status.HTTP_201_CREATED,
-                )
-                pass
-        except Exception as exc:
-            logger.error(f"An exception occured during policy purchase: {exc}")
-            return Response(
-                {"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        pass
 
     @action(detail=False, methods=["post"])
     def renew(self, request, *args, **kwargs):

--- a/superpool/api/api/catalog/views.py
+++ b/superpool/api/api/catalog/views.py
@@ -12,7 +12,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 
-from .serializers import PolicyPurchaseSerializer, PolicySerializer, ProductSerializer
+from .serializers import (PolicyPurchaseSerializer, PolicySerializer,
+                          ProductSerializer)
 from .services import PolicyService, ProductService
 
 logger = logging.getLogger(__name__)
@@ -208,7 +209,7 @@ class PolicyAPIViewSet(
         """
         pass
 
-    @action(details=False, methods=["post"])
+    @action(detail=False, methods=["post"])
     def search(self, request, **extra_kwargs):
         """
         Action that allows you to search or filter for a policy based on

--- a/superpool/api/api/integrations/heirs/services.py
+++ b/superpool/api/api/integrations/heirs/services.py
@@ -3,14 +3,21 @@ import uuid
 from typing import List, TypedDict, Union
 
 from api.integrations.heirs.client import HeirsLifeAssuranceClient
-from core.providers.integrations.heirs.registry import (APIErrorResponse,
-                                                        AutoPolicy,
-                                                        CustomerInfo,
-                                                        InsuranceProduct,
-                                                        Policy, PolicyInfo,
-                                                        Product,
-                                                        QuoteAPIResponse,
-                                                        QuoteDefinition)
+from core.providers.integrations.heirs.registry import (
+    APIErrorResponse,
+    AutoPolicy,
+    BikerPolicy,
+    CustomerInfo,
+    InsuranceProduct,
+    MotorPolicy,
+    PersonalAccidentPolicy,
+    Policy,
+    PolicyInfo,
+    Product,
+    QuoteAPIResponse,
+    QuoteDefinition,
+    TravelPolicyClass,
+)
 from django.conf import settings
 
 
@@ -153,7 +160,7 @@ class HeirsAssuranceService:
             return f"{settings.HEIRS_ASSURANCE_STAGING_URL}/motor/{product_id}/policy"
         elif isinstance(product_class, BikerPolicy):
             return f"{settings.HEIRS_ASSURANCE_STAGING_URL}/biker/{product_id}/policy"
-        elif isinstance(product_class, TravelPolicy):
+        elif isinstance(product_class, TravelPolicyClass):
             return f"{settings.HEIRS_ASSURANCE_STAGING_URL}/travel/{product_id}/policy"
         elif isinstance(product_class, PersonalAccidentPolicy):
             return f"{settings.HEIRS_ASSURANCE_STAGING_URL}/personal-accident/{product_id}/policy"

--- a/superpool/api/api/integrations/heirs/services.py
+++ b/superpool/api/api/integrations/heirs/services.py
@@ -3,21 +3,18 @@ import uuid
 from typing import List, TypedDict, Union
 
 from api.integrations.heirs.client import HeirsLifeAssuranceClient
-from core.providers.integrations.heirs.registry import (
-    APIErrorResponse,
-    AutoPolicy,
-    BikerPolicy,
-    CustomerInfo,
-    InsuranceProduct,
-    MotorPolicy,
-    PersonalAccidentPolicy,
-    Policy,
-    PolicyInfo,
-    Product,
-    QuoteAPIResponse,
-    QuoteDefinition,
-    TravelPolicyClass,
-)
+from core.providers.integrations.heirs.registry import (APIErrorResponse,
+                                                        AutoPolicy,
+                                                        BikerPolicy,
+                                                        CustomerInfo,
+                                                        InsuranceProduct,
+                                                        MotorPolicy,
+                                                        PersonalAccidentPolicy,
+                                                        Policy, PolicyInfo,
+                                                        Product,
+                                                        QuoteAPIResponse,
+                                                        QuoteDefinition,
+                                                        TravelPolicyClass)
 from django.conf import settings
 
 

--- a/superpool/api/api/integrations/heirs/tests/test_integration.py
+++ b/superpool/api/api/integrations/heirs/tests/test_integration.py
@@ -4,6 +4,10 @@ import pytest
 from api.integrations.heirs.client import HeirsLifeAssuranceClient
 from api.integrations.heirs.services import HeirsAssuranceService
 from core.providers.integrations.heirs.registry import (
+    MotorPolicy,
+    MotorPolicyRequest,
+    PersonalAccidentPolicy,
+    PersonalAccidentPolicyRequest,
     TravelPolicyClass,
     TravelPolicyRequest,
 )
@@ -154,16 +158,17 @@ def test_fetch_personal_accident_quotes(mocker):
 
 def test_register_personal_accident_policy(service, customer_fixture, mocker):
     product_id = "2032"
-    register_travel_policy_endpoint = (
-        f"{settings.HEIRS_ASSURANCE_STAGING_URL}/{product_id}/policy"
+    register_personal_accident_endpoint = (
+        f"{settings.HEIRS_ASSURANCE_STAGING_URL}/personal-accident/{product_id}/policy"
     )
     mock_post = mocker.patch.object(HeirsLifeAssuranceClient, "post")
+    mock_post.return_value = {"policy_id": "20425", "status": "success"}
 
-    policy_details = TravelPolicyRequest(
+    accident_policy_details = PersonalAccidentPolicyRequest(
         policyHolderId="holder_1",
         items=[customer_fixture["Jane Doe"]],
     )
-    product = TravelPolicyClass(policy_details=policy_details)
+    product = PersonalAccidentPolicy(policy_details=accident_policy_details)
 
     response = service.register_policy(1, product)
 
@@ -173,17 +178,55 @@ def test_register_personal_accident_policy(service, customer_fixture, mocker):
         "items": [customer_fixture["Jane Doe"]],
     }
 
-    assert isinstance(response["policyId"], str)
+    assert isinstance(response["policy_id"], str)
     assert response["status"] == "success"
     assert response.status_code == 201
-    assert mock_post.assert_called_once_with(
-        register_travel_policy_endpoint, test_payload
+    mock_post.assert_called_once_with(register_personal_accident_endpoint, test_payload)
+
+
+def test_register_travel_policy(service, customer_fixture, mocker):
+    product_id = "1212"
+    register_travel_policy_endpoint = (
+        f"{settings.HEIRS_ASSURANCE_STAGING_URL}/travel/{product_id}/policy"
     )
+    mock_post = mocker.patch.object(HeirsLifeAssuranceClient, "post")
+    mock_post.return_value = {"policy_id": "80801", "status": "success"}
+
+    test_payload = {
+        "policyHolderId": "holder_1",
+        "items": [customer_fixture["John Doe"]],
+    }
+
+    travel_policy_details = TravelPolicyRequest(
+        policyHolderId="holder_1", items=[customer_fixture["John Doe"]]
+    )
+    product = TravelPolicyClass(travel_policy_details)
+    response = service.register_policy(2, product)
+
+    assert response.status_code == 201
+    assert response["policy_id"] == "80801"
+    mock_post.assert_called_once_with(register_travel_policy_endpoint, test_payload)
 
 
-def test_register_travel_policy(service, mocker):
-    pass
+def test_register_auto_policy(service, customer_fixture, mocker):
+    product_id = "AU2345X"
+    register_motor_policy_endpoint = (
+        f"{settings.HEIRS_ASSURANCE_STAGING_URL}/motor/{product_id}/policy"
+    )
+    mock_post = mocker.patch.object(HeirsLifeAssuranceClient, "post")
+    mock_post.return_value = {"policy_id": "MOTO22335", "status": "success"}
 
+    test_payload = {
+        "policyHolderId": "holder_1",
+        "items": [customer_fixture["John Doe"]],
+    }
 
-def test_register_auto_policy(service, mocker):
-    pass
+    motor_policy_details = MotorPolicyRequest(
+        policyHolderId="holder_1", items=[customer_fixture["John Doe"]]
+    )
+    product = MotorPolicy(motor_policy_details)
+    response = service.register_policy(3, product)
+
+    assert response.status_code == 201
+    assert response["policy_id"] == "MOTO22335"
+    mock_post.assert_called_once_with(register_motor_policy_endpoint, test_payload)

--- a/superpool/api/core/catalog/models.py
+++ b/superpool/api/core/catalog/models.py
@@ -156,7 +156,7 @@ class Policy(TimestampMixin, TrashableModelMixin, models.Model):
 
 class Quote(models.Model):
     id = models.CharField(max_length=80, primary_key=True, unique=True, editable=False)
-    base_price = models.DecimalField(decimal_places=2)
+    base_price = models.DecimalField(max_digits=10, decimal_places=2)
 
     class Meta:
         verbose_name = "quote"

--- a/superpool/api/core/catalog/models.py
+++ b/superpool/api/core/catalog/models.py
@@ -152,3 +152,12 @@ class Policy(TimestampMixin, TrashableModelMixin, models.Model):
             models.Index(fields=["policy_holder"]),
             models.Index(fields=["provider_id"]),
         ]
+
+
+class Quote(models.Model):
+    id = models.CharField(max_length=80, primary_key=True, unique=True, editable=False)
+    base_price = models.DecimalField(decimal_places=2)
+
+    class Meta:
+        verbose_name = "quote"
+        verbose_name_plural = "quotes"

--- a/superpool/api/core/providers/integrations/heirs/registry.py
+++ b/superpool/api/core/providers/integrations/heirs/registry.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import List, Optional, TypedDict, Union
 
+from _typeshed import StrEnum
 from api.integrations.heirs.client import HeirsLifeAssuranceClient
 
 
@@ -194,6 +195,19 @@ class PersonalAccidentPerson(TypedDict, total=False):
     gender: str
     phone: str
     occupation: str
+
+
+class MotorParticulars(TypedDict, total=False):
+    owner: str
+    make: str
+    model: str
+    year: int
+    chassis: str
+    registrationNumber: str
+    engineNumber: str
+    value: int
+    use: str  # could be private or commercial
+    type: str  # could be saloon, suv, light truck or heavy duty truck
 
 
 class PersonalAccidentPolicyRequest(TypedDict):

--- a/superpool/api/core/providers/integrations/heirs/registry.py
+++ b/superpool/api/core/providers/integrations/heirs/registry.py
@@ -1,7 +1,7 @@
 import abc
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional, TypedDict, Union
+from typing import List, Optional, TypedDict, Union
 
 from api.integrations.heirs.client import HeirsLifeAssuranceClient
 
@@ -149,4 +149,100 @@ QuoteDefinition = Union[
     TravelQuoteParams, PersonalAccidentQuoteParams, MotorQuoteParams, BikerQuoteParams
 ]
 
+
 # POLICIES IMPLEMENTATION
+class TravelPerson(TypedDict, total=False):
+    firstName: str
+    lastName: str
+    otherName: str
+    dateOfBirth: str
+    startDate: str
+    endDate: str
+    categoryName: str
+    country_id: str
+    email: str
+    address: str
+    nextOfKinName: str
+    relation: str
+    passportNo: str
+    partnersEmail: str
+    gender: str
+    phone: str
+    occupation: str
+
+
+class TravelPolicyRequest(TypedDict):
+    policyHolderId: str
+    items: List[TravelPerson]
+
+
+class PersonalAccidentPerson(TypedDict, total=False):
+    firstName: str
+    lastName: str
+    otherName: str
+    dateOfBirth: str
+    startDate: str
+    endDate: str
+    categoryName: str
+    country_id: str
+    email: str
+    address: str
+    nextOfKinName: str
+    relation: str
+    passportNo: str
+    partnersEmail: str
+    gender: str
+    phone: str
+    occupation: str
+
+
+class PersonalAccidentPolicyRequest(TypedDict):
+    policyHolderId: str
+    items: List[PersonalAccidentPerson]
+
+
+class MotorPolicyRequest(TypedDict, total=False):
+    policyHolderId: str
+    items: List[MotorParticulars]
+
+
+class BikerPolicyRequest(TypedDict, total=False):
+    policyHolderId: str
+    items: List[MotorParticulars]
+
+
+class InsuranceProduct:
+    def to_dict(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class MotorPolicy(InsuranceProduct):
+    def __init__(self, policy_details: MotorPolicyRequest) -> None:
+        self.policy_details = policy_details
+
+    def to_dict(self):
+        return self.policy_details
+
+
+class BikerPolicy(InsuranceProduct):
+    def __init__(self, policy_details: BikerPolicyRequest) -> None:
+        self.policy_details = policy_details
+
+    def to_dict(self):
+        return self.policy_details
+
+
+class PersonalAccidentPolicy(InsuranceProduct):
+    def __init__(self, policy_details: PersonalAccidentPolicyRequest) -> None:
+        self.policy_details = policy_details
+
+    def to_dict(self):
+        return self.policy_details
+
+
+class TravelPolicyClass(InsuranceProduct):
+    def __init__(self, policy_details: TravelPolicyRequest) -> None:
+        self.policy_details = policy_details
+
+    def to_dict(self):
+        return self.policy_details

--- a/superpool/api/core/providers/integrations/heirs/registry.py
+++ b/superpool/api/core/providers/integrations/heirs/registry.py
@@ -148,3 +148,5 @@ class PersonalAccidentQuoteParams(TypedDict):
 QuoteDefinition = Union[
     TravelQuoteParams, PersonalAccidentQuoteParams, MotorQuoteParams, BikerQuoteParams
 ]
+
+# POLICIES IMPLEMENTATION


### PR DESCRIPTION
This PR setups a single, unified interface for registering policies on the Heirs API.
It is intended to take the `Product Class` to be bought and the `Product ID` and register
the product into the respective product class.
