### PR TITLE
Hotfix - Failing OpenAPI Docs

### DIFF
--- a/superpool/api/api/claims/serializers.py
+++ b/superpool/api/api/claims/serializers.py
@@ -158,7 +158,7 @@ class WitnessSerializer(serializers.Serializer):
 class ClaimDocumentSerializer(serializers.ModelSerializer):
     class Meta:
         model = ClaimDocument
-        fields = ["document_name", "evidence_type", "blob", "uploaded_at"]
+        fields = ["document_name", "evidence_type", "document_url", "uploaded_at"]
 
 
 class ClaimDetailsSerializer(serializers.Serializer):

--- a/superpool/api/api/claims/serializers.py
+++ b/superpool/api/api/claims/serializers.py
@@ -102,14 +102,16 @@ class ClaimResponseSerializer(serializers.ModelSerializer):
 
     claim_id = serializers.UUIDField(source="id")
     claim_status = serializers.CharField(source="status")
-    policy_number = serializers.CharField(source="policy.policy_id")
+    policy_id = serializers.CharField(source="policy.policy_id")
     insurer = serializers.CharField(source="policy.provider.name")
 
     class Meta:
         model = Claim
         fields = [
             "claim_id",
+            "policy_id",
             "claim_status",
+            "insurer",
         ]
 
 


### PR DESCRIPTION
- **fix: Field name `blob` is not valid for model `ClaimDocument`**
- **fix: declared fields not included in `serializer.Meta.fields`**
