### PR TITLE
hotfix/merchant registration not sending email verification

### DIFF
--- a/superpool/api/api/merchants/views.py
+++ b/superpool/api/api/merchants/views.py
@@ -3,14 +3,18 @@ from typing import Any
 
 from api.app_auth.authentication import APIKeyAuthentication
 from api.merchants.exceptions import MerchantDeactivationError
-from api.merchants.serializers import (CreateMerchantSerializer,
-                                       MerchantSerializer,
-                                       MerchantSerializerV2,
-                                       MerchantWriteSerializerV2)
+from api.merchants.serializers import (
+    CreateMerchantSerializer,
+    MerchantSerializer,
+    MerchantSerializerV2,
+    MerchantWriteSerializerV2,
+)
 from api.merchants.services import MerchantService
-from core.merchants.errors import (MerchantAlreadyExists,
-                                   MerchantObjectDoesNotExist,
-                                   MerchantUpdateError)
+from core.merchants.errors import (
+    MerchantAlreadyExists,
+    MerchantObjectDoesNotExist,
+    MerchantUpdateError,
+)
 from core.merchants.models import Merchant
 from django.http.response import Http404
 from drf_spectacular.utils import extend_schema
@@ -50,8 +54,7 @@ class MerchantAPIViewsetV2(mixins.CreateModelMixin, viewsets.GenericViewSet):
         """
         This action allows you to register a new merchant
         """
-        from core.utils import (generate_verification_token,
-                                send_verification_email)
+        from core.utils import generate_verification_token, send_verification_email
 
         serializer = self.get_serializer(data=request.data)
         try:
@@ -69,6 +72,10 @@ class MerchantAPIViewsetV2(mixins.CreateModelMixin, viewsets.GenericViewSet):
         # generate and send a verification email to the merchant
         merchant = serializer.instance
         verification_token = generate_verification_token()
+
+        # import pdb
+        #
+        # pdb.set_trace()
         try:
             send_verification_email(merchant.business_email, verification_token)
         except Exception as email_exc:
@@ -76,7 +83,10 @@ class MerchantAPIViewsetV2(mixins.CreateModelMixin, viewsets.GenericViewSet):
                 f"Error sending verification email to this merchant email: {email_exc}"
             )
             return Response(
-                {"error": "Merchant created, but sending email verification failed."},
+                {
+                    "error": "Merchant created, but sending email verification failed.",
+                    "data": serializer.data,
+                },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/superpool/api/config/settings/base.py
+++ b/superpool/api/config/settings/base.py
@@ -256,6 +256,8 @@ LOGGING = {
 
 BACKEND_URL = "https://superpool-v3-dev-ynoamqpukq-uc.a.run.app"
 
+BASE_URL = env("BASE_URL", default="http://localhost:8000")
+
 ADMINS = []
 ADMINS += env.list("SUPERPOOL_ADMINS", default=[])
 MANAGERS = ADMINS

--- a/superpool/api/core/utils.py
+++ b/superpool/api/core/utils.py
@@ -1,33 +1,37 @@
 import random
 import string
 import uuid
+from .emails import PendingVerificationEmail
+from django.conf import settings
 
 from core.merchants.models import Merchant
+
+DEFAULT_FROM_EMAIL = settings.DEFAULT_FROM_EMAIL
+BASE_URL = settings.BASE_URL
+
+print(f"BASE_URL: {BASE_URL}")
+print(f"EMAIL: {DEFAULT_FROM_EMAIL}")
 
 
 def generate_verification_token() -> str:
     """
     Generates a verification token for email verification
     """
-    return random.choice(
-        [
-            "".join(random.choices(string.ascii_letters + string.digits, k=1))
-            for _ in range(6)
-        ]
-    )
+    return "".join(random.choices(string.ascii_letters + string.digits, k=6))
 
 
 def send_verification_email(email: str, token: str) -> None:
     """
     Sends an email to the merchant to verify their email address
     """
-    from core.emails import PendingVerificationEmail
-    from django.conf import settings
 
-    CONFIRMATION_URL = f"{settings.BACKEND_URL}/verify-email?token={token}"
+    CONFIRMATION_URL = f"{BASE_URL}/verify-email?token={token}"
 
     verification_email = PendingVerificationEmail(
-        confirm_url=CONFIRMATION_URL, to=email, from_=settings.FROM_EMAIL
+        confirm_url=CONFIRMATION_URL,
+        to=email,
+        from_=DEFAULT_FROM_EMAIL,
+        token=token,
     )
     verification_email.send()
 

--- a/superpool/api/templates/superpool/emails/verification_emailV2.html
+++ b/superpool/api/templates/superpool/emails/verification_emailV2.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Unyte - Verify Your Email</title>
+  </head>
+  <body>
+    <h1>
+      Welcome onboard, Merchant! Help us get to know your business better.
+    </h1>
+    <p>Please verify your email address by clicking on the link below:</p>
+    <a href="{{ confirm_url }}">Verify Email</a>
+    <p>If the link doesn't work, use this token: {{ token }}</p>
+    <p>Or copy and paste this URL into your browser: {{ confirm_url }}</p>
+    <p>This link will expire in 24 hours.</p>
+    <p>If you didn't create an account with Unyte, please ignore this email.</p>
+    <p>Thank you for choosing Unyte!</p>
+  </body>
+</html>


### PR DESCRIPTION
This patch fixes the issue of merchants not recieving email verification. It contain the following changes:

- **chore: add `BASE URL` for use within emails and other contexts**
- **fix: generate token not generating 6-character token**
- **feat: verification email template to isolate the problem**
- **fix: merchant not recieving email for verification**
