### PR TITLE
fix: ensure serializer use `customer` for claimant updates

### DIFF
--- a/superpool/api/api/claims/views.py
+++ b/superpool/api/api/claims/views.py
@@ -325,6 +325,7 @@ class ClaimsViewSet(viewsets.ViewSet):
         service = self.get_service()
         serializer_class = self.get_serializer_class()
         serializer = serializer_class(data=request.data, partial=True)
+
         try:
             instance = service.get_claim(claim_id=pk)
         except Claim.DoesNotExist:


### PR DESCRIPTION
- Updated `ClaimUpdateSerializer` to use 'claimant' alias to represent ``instance.customer` for updating claimant metadata.
- Adjusted `update` method to ensure correct field updates on the `customer` model.
- Maintained existing validation and update restrictions for fields in `claim_details`, `witness_details`, and `authority_report`.

This change ensures compatibility with the current model structure while preparing for future updates where `claimant` in the model will replace `customer`.
