### PR TITLE
[Feature] Enhance insurance coverage search with admin-only filters for Insurer Name and Insurer ID

### DIFF
--- a/superpool/api/api/catalog/permissions.py
+++ b/superpool/api/api/catalog/permissions.py
@@ -1,0 +1,20 @@
+from rest_framework import permissions
+
+
+class AdminOnlyInsurerFilterPermission(permissions.BasePermission):
+    """
+    Custom permission to restrict access to 'insurer_name' and 'insurer_id' filters to admin users only.
+    """
+
+    def has_permissions(self, request, view) -> bool:
+        # set the query params
+
+        query_params = request.query_params
+        insurer_name = query_params.get("insurer_name")
+        insurer_id = query_params.get("insurer_id")
+
+        if insurer_name and insurer_id:
+            # confirm if the user is an admin or a customer support
+            return request.user and request.user.is_staff
+        # other-wise any other filters? No problem give every one access
+        return True

--- a/superpool/api/api/catalog/views.py
+++ b/superpool/api/api/catalog/views.py
@@ -1267,7 +1267,11 @@ class ProductCoverageRetrieveView(generics.RetrieveAPIView):
 
 @extend_schema(
     summary="Search for insurance coverages",
-    description="Search for insurance coverages using various parameters. Supports both partial and exact case-insensitive matches.",
+    description=(
+        "This API allows users to search for insurance coverages using various filters. "
+        "Admin users (staff - customer-support) have additional access to search using the insurer name and insurer ID. "
+        "Non-admin users can only search by coverage name, coverage ID, and product ID."
+    ),
     tags=["Coverage"],
     parameters=[
         OpenApiParameter(
@@ -1287,12 +1291,22 @@ class ProductCoverageRetrieveView(generics.RetrieveAPIView):
         ),
         OpenApiParameter(
             "insurer_name",
-            description="Case-insensitive name of the insurer. Allows partial and exact matches.",
+            description=(
+                "Admin-only filter. Case-insensitive search by insurer name. "
+                "This filter is accessible only to customer support users."
+            ),
+            required=False,
+            type=OpenApiTypes.STR,
+            examples=[
+                OpenApiExample("Partial match", value="Health Plus"),
+                OpenApiExample("Exact match", value="Global Insurers Ltd."),
+            ],
         ),
         OpenApiParameter(
             "insurer_id",
             type=OpenApiTypes.UUID,
-            description="Unique identifier of the insurer",
+            description="Admin-only filter. Search by unique insurer ID (UUID). Accessible only to admin users.",
+            required=False,
         ),
     ],
     responses=OpenApiResponse(


### PR DESCRIPTION
This PR introduces enhancements to the insurance coverage search functionality by adding admin-only filters for searching coverages by insurer name and insurer ID. These filters are restricted to admin users while maintaining public access to other filters like coverage_name, coverage_id, and product_id.
Key Changes:

- Admin-only filters:

  - Added the ability to filter coverages using insurer_name (partial case-insensitive match).
  - Added the ability to filter coverages using insurer_id (exact match).
  - Access to these filters is restricted to admin users only, using the AdminOnlyInsurerFilterPermission class.

- Public filters:
  - Existing public filters (coverage_name, coverage_id, and product_id) remain accessible to all users.
