### PR TITLE
chore: disable claim submission at instance creation

### DIFF
--- a/superpool/api/api/claims/serializers.py
+++ b/superpool/api/api/claims/serializers.py
@@ -272,8 +272,8 @@ class ClaimRequestSerializer(serializers.Serializer):
 
         return attrs
 
-    def create(self, validated_data):
-        ClaimService.submit_claim(validated_data)
+    # def create(self, validated_data):
+    #     ClaimService.submit_claim(validated_data)
 
 
 class ClaimUpdateSerializer(serializers.Serializer):


### PR DESCRIPTION
We should only allow claims request to be handled when explicitly
called, and not implicitly at instance creation as this could lead
to multiple instance creatiion of claim objects for the single request
