### PR TITLE
[CI] - Fix failing pipeline due to non-existent db url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
           DISABLE_AUTH: ${{ secrets.DISABLE_AUTH }}
           HEIRS_API_KEY: ${{ secrets.HEIRS_API_KEY }}
           HEIRS_APP_ID: ${{ secrets.HEIRS_APP_ID }}
+          SUPERPOOL_TEST_PROD_DB_URL: ${{secrets.SUPERPOOL_TEST_PROD_DB_URL}}
         run: |
           cd superpool/api
           poetry run pytest .


### PR DESCRIPTION
With this, CI should automatically pick up the db url for tests and be
able to now execute test on its own db.
